### PR TITLE
npm run setupを実行するためにはpublicフォルダが必要であるため。ただしpublicフォルダはビルド済み資源を格納するため…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ typings/
 
 # Nuxt generate
 functions/nuxt
-public
+public/assets/*
 
 # vuepress build output
 .vuepress/dist


### PR DESCRIPTION
…、当該パスはgitignore対象に