### PR TITLE
論文一覧画面の詳細ボタンを削除し、カード全体を押下可能に

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -62,7 +62,4 @@ export default {
 .abst {
   letter-spacing: 0.5px
 }
-.detail-btn {
-  margin: 15px 0px 0px 0px;
-}
 </style>

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,18 +1,9 @@
 <template>
   <div class="card">
-    <div class="card-body">
+    <div class="card-body" @click="click">
       <h5 class="abst font-weight-bold">
         {{ title }}
       </h5>
-      <div class="detail-btn text-center">
-        <nuxt-link
-          class="btn btn-success"
-          role="button"
-          :to="{name: contentType+'-slug', params: {slug: id}}"
-        >
-          詳細
-        </nuxt-link>
-      </div>
     </div>
     <div class="card-created-date card-footer text-muted">
       <div class="card-published-date text-muted small">
@@ -51,6 +42,11 @@ export default {
       type: String,
       default: 'article'
     }
+  },
+  methods: {
+    click() {
+      this.$emit('card-click', this.id)
+    }
   }
 }
 </script>
@@ -58,6 +54,7 @@ export default {
 <style scoped>
 .card {
   margin: 5px;
+  cursor: pointer;
 }
 .card-published-date{
   white-space: nowrap;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -63,8 +63,7 @@ export default {
   white-space: nowrap;
 }
 .abst {
-  letter-spacing: 0.5px;
-  height: 15vh;
+  letter-spacing: 0.5px
 }
 .detail-btn {
   margin: 15px 0px 0px 0px;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -63,7 +63,8 @@ export default {
   white-space: nowrap;
 }
 .abst {
-  letter-spacing: 0.5px
+  letter-spacing: 0.5px;
+  height: 15vh;
 }
 .detail-btn {
   margin: 15px 0px 0px 0px;

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -56,6 +56,9 @@ export default {
   margin: 5px;
   cursor: pointer;
 }
+.card:hover {
+  border-color: black;
+}
 .card-published-date{
   white-space: nowrap;
 }

--- a/pages/articles/index.vue
+++ b/pages/articles/index.vue
@@ -20,6 +20,7 @@
           :date="article.createdAt"
           :published-date="article.publishedDate"
           content-type="articles"
+          @card-click="toSlug"
         />
         <result-card
           v-show="resultCardIsVisible"
@@ -112,6 +113,9 @@ export default {
       this.clearCategory()
       this.setFilteringWords({ filteringWords })
       this.resultCardIsVisible = false
+    },
+    toSlug(id) {
+      this.$router.push(`/articles/${id}`)
     }
   }
 }


### PR DESCRIPTION
↓こんな感じで揃っている方がきれいな気がしたので。

![スクリーンショット 2019-06-17 0 37 11](https://user-images.githubusercontent.com/8016453/59566225-139d1080-9098-11e9-82ae-69ab3791cad5.png)
