### PR TITLE
記事一覧の左右のカード余白の追加

### DIFF
--- a/components/SearchForm.vue
+++ b/components/SearchForm.vue
@@ -72,7 +72,6 @@ export default {
 .form-dev {
   text-align: center;
   width: 80%;
-  margin: 1rem auto 1rem auto;
 }
 .category-form {
   width: 20%;

--- a/pages/articles/index.vue
+++ b/pages/articles/index.vue
@@ -5,12 +5,14 @@
       <h5>SOTA of Medical-AI</h5>
       <h6>最新の医療AI論文を日本語で</h6>
     </div>
-    <search-form
-      @request-filter="mutateFilterQueryFilter"
-      @request-restore="mutateFilterQueryReset"
-    />
-    <select-form-sort class="select-form" @request-sort="changeSortOrder" />
     <div class="container-fluid">
+      <search-form
+        @request-filter="mutateFilterQueryFilter"
+        @request-restore="mutateFilterQueryReset"
+      />
+    </div>
+    <div class="container-fluid">
+      <select-form-sort class="select-form" @request-sort="changeSortOrder" />
       <div id="articles-card-column" class="card-deck">
         <article-card
           v-for="article in shownArticles"
@@ -130,8 +132,7 @@ export default {
   }
   .select-form {
     width: 15rem;
-    margin-top: 2rem;
-    margin-left: 1rem
+    margin: 2rem 0 1rem 0;
   }
   .under-search {
     display: inline-block;
@@ -141,5 +142,6 @@ export default {
     padding-left: 15px;
     margin-right: auto;
     margin-left: auto;
+    max-width: 95%;
   }
 </style>


### PR DESCRIPTION
記事一覧ページの左右のマージンを調整、それに伴うsearchformとselectformの位置調整
close #62