### PR TITLE
デザイン コラムページ左右の余白を追加

### DIFF
--- a/pages/columns/index.vue
+++ b/pages/columns/index.vue
@@ -75,5 +75,6 @@ export default {
     padding-left: 15px;
     margin-right: auto;
     margin-left: auto;
+    max-width: 95%;
   }
 </style>


### PR DESCRIPTION
コラム一覧ページ、とりあえず左右の余白を取ったので、おかしな感じは減っていると思います。